### PR TITLE
Handle exceptions in withSpan, set error tag to true and rethrow

### DIFF
--- a/src/LightStep/HighLevel/IO.hs
+++ b/src/LightStep/HighLevel/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LightStep.HighLevel.IO 
   ( module LightStep.HighLevel.IO
   , module LightStep.LowLevel
@@ -28,7 +29,10 @@ withSpan opName action =
   bracket
     (pushSpan opName)
     popSpan 
-    (const action)
+    (const action')
+  where action' = action `catch` \e -> do
+        setTag "error" "true"
+        throwM (e :: SomeException)
 
 pushSpan :: T.Text -> IO ()
 pushSpan opName = do

--- a/src/LightStep/HighLevel/IO.hs
+++ b/src/LightStep/HighLevel/IO.hs
@@ -29,10 +29,7 @@ withSpan opName action =
   bracket
     (pushSpan opName)
     popSpan 
-    (const action')
-  where action' = action `catch` \e -> do
-        setTag "error" "true"
-        throwM (e :: SomeException)
+    (const (onException action (setTag "error" "true")))
 
 pushSpan :: T.Text -> IO ()
 pushSpan opName = do


### PR DESCRIPTION
Addresses issue #5. In `withSpan`, any exception thrown by `action` will be caught, and the `"error"` tag will be set to `"true"`, the exception is then rethrown.

I have verified the tag is set correctly by inspecting `globalSharedMutableSingletonState` after running `withSpan` with an action that throws. Not sure if this is the correct approach, looking forward for some feedback!