### PR TITLE
Export SpanContext

### DIFF
--- a/src/LightStep/HighLevel/IO.hs
+++ b/src/LightStep/HighLevel/IO.hs
@@ -4,6 +4,7 @@ module LightStep.HighLevel.IO
   ( module LightStep.HighLevel.IO,
     module LightStep.LowLevel,
     module LightStep.Config,
+    SpanContext,
   )
 where
 


### PR DESCRIPTION
Exported functions return the SpanContext but it is not exported itself.