### PR TITLE
Implement format and different propagators

### DIFF
--- a/examples/req/Main.hs
+++ b/examples/req/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Control.Concurrent
+import Data.CaseInsensitive (original)
+import Data.HashMap.Strict (toList)
 import LightStep.HighLevel.IO
-import LightStep.Propagation (b3headersForSpanContext)
+import LightStep.Propagation (b3Propagator, hmFromHttpHeaders, inject)
 import Network.HTTP.Req
 
 clientMain :: IO ()
@@ -11,7 +13,7 @@ clientMain = do
     setTag "span.kind" "client"
     setTag "component" "http"
     Just ctx <- currentSpanContext
-    let opts = port 8736 <> foldMap (\(k, v) -> header k v) (b3headersForSpanContext ctx)
+    let opts = port 8736 <> foldMap (\(k, v) -> header (original k) v) (toList (hmFromHttpHeaders (inject b3Propagator ctx Nothing)))
         url = http "127.0.0.1" /: "test"
     _ <- runReq defaultHttpConfig $ req GET url NoReqBody ignoreResponse opts
     pure ()

--- a/lightstep-haskell.cabal
+++ b/lightstep-haskell.cabal
@@ -148,9 +148,11 @@ executable lightstep-haskell-req-example
   build-depends:
       base >=4.9 && <5
     , lightstep-haskell
+    , case-insensitive
     , http-types
     , text
     , req >= 3.0.0
+    , unordered-containers
 
 executable lightstep-haskell-stress-test
   import: options

--- a/lightstep-haskell.cabal
+++ b/lightstep-haskell.cabal
@@ -74,6 +74,7 @@ library
     , bytestring
     , chronos
     , containers
+    , hashable
     , http-types
     , http2-client >= 0.9.0.0
     , http2-client-grpc >= 0.8.0.0

--- a/unit-test/TestPropagation.hs
+++ b/unit-test/TestPropagation.hs
@@ -14,18 +14,20 @@ prop_u64_roundtrip :: Word64 -> Bool
 prop_u64_roundtrip x =
   Just x == decode_u64 (encode_u64 x)
 
-prop_ot_headers_roundtrip :: Word64 -> Word64 -> Bool
-prop_ot_headers_roundtrip tid sid =
+prop_text_propagator_roundtrip :: Word64 -> Word64 -> Bool
+prop_text_propagator_roundtrip tid sid =
   let c =
         defMessage
           & traceId .~ tid
           & spanId .~ sid
-   in Just c == extractSpanContextFromRequestHeaders (headersForSpanContext c)
+      p = textPropagator
+   in Just c == extract p (inject p c Nothing)
 
-prop_b3_headers_roundtrip :: Word64 -> Word64 -> Bool
-prop_b3_headers_roundtrip tid sid =
+prop_b3_propagator_roundtrip :: Word64 -> Word64 -> Bool
+prop_b3_propagator_roundtrip tid sid =
   let c =
         defMessage
           & traceId .~ tid
           & spanId .~ sid
-   in Just c == extractSpanContextFromRequestHeaders (b3headersForSpanContext c)
+      p = b3Propagator
+   in Just c == extract p (inject p c Nothing)


### PR DESCRIPTION
The implementation of the formats as hash maps is taken from the
specification which states that they are string-to-string maps. Example
implementations were done for a text map based propagator as well as two
based on http headers.