### PR TITLE
Add `Ot-Tracer-Sampled = true` and change formats

### DIFF
--- a/examples/req/Main.hs
+++ b/examples/req/Main.hs
@@ -2,9 +2,8 @@
 
 import Control.Concurrent
 import Data.CaseInsensitive (original)
-import Data.HashMap.Strict (toList)
 import LightStep.HighLevel.IO
-import LightStep.Propagation (b3Propagator, hmFromHttpHeaders, inject)
+import LightStep.Propagation (b3Propagator, inject)
 import Network.HTTP.Req
 
 clientMain :: IO ()
@@ -13,7 +12,7 @@ clientMain = do
     setTag "span.kind" "client"
     setTag "component" "http"
     Just ctx <- currentSpanContext
-    let opts = port 8736 <> foldMap (\(k, v) -> header (original k) v) (toList (hmFromHttpHeaders (inject b3Propagator ctx Nothing)))
+    let opts = port 8736 <> foldMap (\(k, v) -> header (original k) v) (inject b3Propagator ctx Nothing)
         url = http "127.0.0.1" /: "test"
     _ <- runReq defaultHttpConfig $ req GET url NoReqBody ignoreResponse opts
     pure ()

--- a/examples/req/Main.hs
+++ b/examples/req/Main.hs
@@ -12,7 +12,7 @@ clientMain = do
     setTag "span.kind" "client"
     setTag "component" "http"
     Just ctx <- currentSpanContext
-    let opts = port 8736 <> foldMap (\(k, v) -> header (original k) v) (inject b3Propagator ctx Nothing)
+    let opts = port 8736 <> foldMap (\(k, v) -> header (original k) v) (inject b3Propagator ctx)
         url = http "127.0.0.1" /: "test"
     _ <- runReq defaultHttpConfig $ req GET url NoReqBody ignoreResponse opts
     pure ()

--- a/src/LightStep/Propagation.hs
+++ b/src/LightStep/Propagation.hs
@@ -25,7 +25,7 @@ type HttpHeaders = [(HeaderName, BS.ByteString)]
 -- protobuf https://github.com/opentracing/basictracer-go/blob/master/wire/wire.proto
 
 data Propagator a = Propagator
-  { inject :: SpanContext -> Maybe a -> a,
+  { inject :: SpanContext -> a,
     extract :: a -> Maybe SpanContext
   }
 
@@ -55,13 +55,12 @@ b3Propagator =
 
 injectSpanContext ::
   (IsString key, Semigroup key) =>
-  key -> SpanContext -> Maybe [(key, BS.ByteString)] -> [(key, BS.ByteString)]
-injectSpanContext prefix ctx (Just hm) =
+  key -> SpanContext -> [(key, BS.ByteString)]
+injectSpanContext prefix ctx =
   [ (prefix <> "Traceid", encode_u64 $ ctx ^. traceId)
   , (prefix <> "Spanid", encode_u64 $ ctx ^. spanId)
   , (prefix <> "Sampled", "true")
-  ] <> hm
-injectSpanContext prefix ctx Nothing = injectSpanContext prefix ctx (Just [])
+  ]
 
 extractSpanContext ::
   (IsString key, Eq key, Semigroup key) =>

--- a/unit-test/TestPropagation.hs
+++ b/unit-test/TestPropagation.hs
@@ -21,7 +21,7 @@ prop_text_propagator_roundtrip tid sid =
           & traceId .~ tid
           & spanId .~ sid
       p = textPropagator
-   in Just c == extract p (inject p c Nothing)
+   in Just c == extract p (inject p c)
 
 prop_b3_propagator_roundtrip :: Word64 -> Word64 -> Bool
 prop_b3_propagator_roundtrip tid sid =
@@ -30,4 +30,4 @@ prop_b3_propagator_roundtrip tid sid =
           & traceId .~ tid
           & spanId .~ sid
       p = b3Propagator
-   in Just c == extract p (inject p c Nothing)
+   in Just c == extract p (inject p c)


### PR DESCRIPTION
- The lightstep go integration of https://github.com/zalando/skipper did not work without the `Ot-Tracer-Sampled = true` header so this was added.
- The format definition was changed from hashmap to lists as this is the more typical representation of request headers